### PR TITLE
fix: early return if path is already absolute

### DIFF
--- a/src/components/OverrideSelector.vue
+++ b/src/components/OverrideSelector.vue
@@ -215,8 +215,8 @@ export default {
       }
 
       this.methodName = methodName;
-      this.copyPasteableFilePath = customFilePath.replace("data/", "");
-      customFilePath = this.fixPath(customFilePath);
+      this.copyPasteableFilePath = this.getRelativePath(customFilePath);
+      customFilePath = this.getAbsolutePath(customFilePath);
       this.customFileType = customFilePath.split(".").pop();
       if (this.customFileType === "phtml") {
         this.customFileType = "php";
@@ -241,11 +241,14 @@ export default {
       //
       // }, 100);
     },
-    fixPath(path) {
+    getAbsolutePath(path) {
       if (path.indexOf(this.selectedMagento2ProjectDir) > -1) {
         return path;
       }
       return this.selectedMagento2ProjectDir + "/" + path;
+    },
+    getRelativePath(path) {
+      return path.replace(this.selectedMagento2ProjectDir + "/", "");
     },
   },
 };

--- a/src/components/OverrideSelector.vue
+++ b/src/components/OverrideSelector.vue
@@ -242,8 +242,8 @@ export default {
       // }, 100);
     },
     fixPath(path) {
-      if (path.indexOf("/data/") > -1) {
-        path = path.split("magento2/")[1];
+      if (path.indexOf(this.selectedMagento2ProjectDir) > -1) {
+        return path;
       }
       return this.selectedMagento2ProjectDir + "/" + path;
     },


### PR DESCRIPTION
Fixes #2.

* Converts the file path to a relative path based on the selectedMagento2ProjectDir for the link to open the file
* Converts the file path to a absolute path based on the selectedMagento2ProjectDir for getting file contents